### PR TITLE
Publish on release action rather than push of tag. 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,8 @@
 name: pypi deploy
 
 on:
+  release:
+    types: [ created ]
   push:
     tags:
       - 'v*'  # Trigger only on tags like v1.2.3


### PR DESCRIPTION
Creating the release in github creates a tag without pushing it so the workflow isn't triggered.